### PR TITLE
Check for and raise error for missing chain ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ You can also build the Docker image locally and then run it as described above:
 docker build . -t pdbegroup/pisa-analysis
 ```
 
+## Error codes
+ - Exit Status `9`: File not found
+
 ## Versioning
 
 We use [SemVer](https://semver.org) for versioning.

--- a/pisa_utils/models/validation_error_handlers.py
+++ b/pisa_utils/models/validation_error_handlers.py
@@ -40,8 +40,7 @@ def trigger_helpful_validation_error(error_details: list[ErrorDetails]):
             )
             raise MissingChainIDError()
 
-        else:
-            LOGGER.warning(f"Pydantic error {i}: Validation error details: {error}")
-            raise ValidationError.from_exception_data(
-                "Unhandled pydantic validation errors", error_details
-            )
+        LOGGER.warning(f"Pydantic error {i}: Validation error details: {error}")
+        raise ValidationError.from_exception_data(
+            "Unhandled pydantic validation errors", error_details
+        )

--- a/pisa_utils/models/validation_error_handlers.py
+++ b/pisa_utils/models/validation_error_handlers.py
@@ -1,0 +1,43 @@
+from pydantic_core import ErrorDetails
+from logging import getLogger
+
+LOGGER = getLogger(__name__)
+
+CHAIN_ID_SYNONYMS = {"chain-1", "chain-2", "chain_id", "monomer_1", "monomer_2"}
+
+
+class MissingChainIDError(Exception):
+    """Custom exception for missing chain ID in the input data."""
+
+    def __init__(self, message: str = None):
+
+        if not message:
+            message = (
+                "File contains unassigned chain IDs. Please make sure all polymer and "
+                "ligand entities in the file have assigned alphanumeric chain IDs."
+            )
+
+        super().__init__(message)
+
+
+def trigger_helpful_validation_error(error_details: list[ErrorDetails]):
+    """
+    Custom validation error handler to check for specific validation errors and raise
+    bespoke exceptions for API to handle accordingly.
+
+    :param error_details: List of validation error details from pydantic validation.
+    :type error_details: list[ErrorDetails]
+    :raises MissingChainIDError: If any validation error indicates missing chain ID
+        assignment in the input data.
+    """
+    LOGGER.warning(f"Iterating over {len(error_details)} pydantic validation errors...")
+
+    for i, error in enumerate(error_details):
+        # auth_asym_id (chain ID) not assigned by user
+        if error["input"] is None and error["loc"][-1] in CHAIN_ID_SYNONYMS:
+            LOGGER.warning(
+                f"Pydantic error {i}: Missing chain ID detected. Details: {error}"
+            )
+            raise MissingChainIDError()
+
+        # Future, bespoke validation error handling...

--- a/pisa_utils/models/validation_error_handlers.py
+++ b/pisa_utils/models/validation_error_handlers.py
@@ -30,14 +30,11 @@ def trigger_helpful_validation_error(error_details: list[ErrorDetails]):
     :raises MissingChainIDError: If any validation error indicates missing chain ID
         assignment in the input data.
     """
-    LOGGER.warning(f"Iterating over {len(error_details)} pydantic validation errors...")
 
     for i, error in enumerate(error_details):
-        # auth_asym_id (chain ID) not assigned by user
+        # Error due to auth_asym_id (chain ID) not assigned by user
         if error["input"] is None and error["loc"][-1] in CHAIN_ID_SYNONYMS:
             LOGGER.warning(
                 f"Pydantic error {i}: Missing chain ID detected. Details: {error}"
             )
             raise MissingChainIDError()
-
-        # Future, bespoke validation error handling...

--- a/pisa_utils/models/validation_error_handlers.py
+++ b/pisa_utils/models/validation_error_handlers.py
@@ -1,3 +1,4 @@
+from pydantic import ValidationError
 from pydantic_core import ErrorDetails
 from logging import getLogger
 
@@ -38,3 +39,9 @@ def trigger_helpful_validation_error(error_details: list[ErrorDetails]):
                 f"Pydantic error {i}: Missing chain ID detected. Details: {error}"
             )
             raise MissingChainIDError()
+
+        else:
+            LOGGER.warning(f"Pydantic error {i}: Validation error details: {error}")
+            raise ValidationError.from_exception_data(
+                "Unhandled pydantic validation errors", error_details
+            )

--- a/pisa_utils/parsers.py
+++ b/pisa_utils/parsers.py
@@ -549,7 +549,6 @@ class ConvertInterfaceXMLToJSONs(ConvertXMLToJSON):
         try:
             interface_output = Interface(**interface_output).model_dump()
         except ValidationError as e:
-            LOGGER.warning(f"Validation error for interface {interface_id}: {e}")
             trigger_helpful_validation_error(e.errors())
 
         # Write interface JSON

--- a/pisa_utils/parsers.py
+++ b/pisa_utils/parsers.py
@@ -6,6 +6,7 @@ import gzip
 
 import gemmi
 import pandas as pd
+from pydantic_core import ValidationError
 import xmltodict
 
 from pisa_utils.models.data_models import (
@@ -17,6 +18,7 @@ from pisa_utils.models.data_models import (
     InterfaceSummary,
 )
 from pisa_utils.models.models import AllowedModelFileFormats
+from pisa_utils.models.validation_error_handlers import trigger_helpful_validation_error
 from pisa_utils.utils import (
     extract_ligand_contents,
     id_is_ligand,
@@ -544,7 +546,11 @@ class ConvertInterfaceXMLToJSONs(ConvertXMLToJSON):
                 molecule["label_seq_id_end"] = label_seq_id_end
 
         # Validate through pydantic model
-        interface_output = Interface(**interface_output).model_dump()
+        try:
+            interface_output = Interface(**interface_output).model_dump()
+        except ValidationError as e:
+            LOGGER.warning(f"Validation error for interface {interface_id}: {e}")
+            trigger_helpful_validation_error(e.errors())
 
         # Write interface JSON
         interface_json_path = os.path.join(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pisa-analysis"
-version = "3.1.5"
+version = "3.1.6"
 description = "This python package works with PISA to analyse data for macromolecular interfaces and interactions in assemblies."
 authors = [
     { name = "Grisell Diaz Leines", email = "gdiazleines@ebi.ac.uk" },

--- a/tests/models/test_validation_error_handlers.py
+++ b/tests/models/test_validation_error_handlers.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from pydantic_core import ErrorDetails
+
+from pisa_utils.models.validation_error_handlers import (
+    MissingChainIDError,
+    trigger_helpful_validation_error,
+)
+
+
+class TestTriggerHelpfulValidationError(TestCase):
+    def test_trigger_missing_chain_in_interface_validation(self):
+        error_details = [
+            ErrorDetails(
+                **{
+                    "type": "string_type",
+                    "loc": ("interface", "other-bonds", "bond", 0, "chain-2"),
+                    "msg": "Input should be a valid string",
+                    "input": None,
+                    "url": "https://errors.pydantic.dev/2.12/v/string_type",
+                }
+            )
+        ]
+
+        with self.assertRaises(MissingChainIDError) as context:  # noqa: F841
+            trigger_helpful_validation_error(error_details)

--- a/uv.lock
+++ b/uv.lock
@@ -725,7 +725,7 @@ wheels = [
 
 [[package]]
 name = "pisa-analysis"
-version = "3.1.5"
+version = "3.1.6"
 source = { editable = "." }
 dependencies = [
     { name = "gemmi" },


### PR DESCRIPTION
Adds a new function that reads through the error message from Pydantic, raising a more informative error that can help users troubleshoot the issue or let an API handle a known error. 

The alternative would be to return only the Pydantic error messages. However, the underlying provenance of these errors are not obvious in some cases. For one tested file, a missing chain ID raises the following message:

```
interface.other-bonds.bond.0.chain-2
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
```

It's not immediately obvious that this error has occurred due to a missing chain ID. 